### PR TITLE
fix: missing order types

### DIFF
--- a/src/api/checkout-v3/interface.ts
+++ b/src/api/checkout-v3/interface.ts
@@ -107,6 +107,7 @@ export interface IOrder {
   recurring_description: string;
   merchant_reference1?: string;
   merchant_reference2?: string;
+  selected_shipping_option?: IShippingOption;
 }
 
 export interface IOrderResponse extends IResponse {

--- a/src/api/checkout-v3/interface.ts
+++ b/src/api/checkout-v3/interface.ts
@@ -32,6 +32,8 @@ export interface IOrderBody {
   merchant_urls: IMerchantObj;
   recurring?: boolean;
   shipping_options?: IShippingOption[];
+  merchant_reference1?: string;
+  merchant_reference2?: string;
 }
 
 export interface IShippingOption {
@@ -103,6 +105,8 @@ export interface IOrder {
   recurring: boolean;
   recurring_token: string;
   recurring_description: string;
+  merchant_reference1?: string;
+  merchant_reference2?: string;
 }
 
 export interface IOrderResponse extends IResponse {


### PR DESCRIPTION
Added missing types for:

- `merchant_reference` (`1` and `2`)
- `selected_shipping_option` 

Following docs from [here](https://developers.klarna.com/api/#checkout-api). 